### PR TITLE
Split of add and add --all into seperate commands.

### DIFF
--- a/bin/gg
+++ b/bin/gg
@@ -25,8 +25,17 @@ switch (cli.command) {
 
 	// Add.
 	case 'a':
-	case 'aa': // Short for 'add all'.
 	case 'add':
+		if(cli.args[1] !== undefined){
+			var options = cli.args[0];
+			var target = cli.args[1];
+			gg.addOptions(options, target);
+		}else{
+			var target = cli.args[0];
+			gg.addSingle(target);
+		}
+		break;
+	case 'aa': // Short for 'add all'.
 		gg.addAll();
 		break;
 

--- a/lib/gg.js
+++ b/lib/gg.js
@@ -59,7 +59,6 @@ exports.addSingle = function(target) {
 
 exports.addOptions = function(options, target){
 	// TODO: Fix the Error Handling! Currently just ignores warnings
-	console.log(options + "  -- " + target);
 	exec('git add -' + options + ' ' + target, function(error, stdout, stderr){
 		if(!stderr.substring(0, 7) === 'warning'){
 			console.log(whoops('[✖] Could not add target specified? Are you sure the target exists?'));

--- a/lib/gg.js
+++ b/lib/gg.js
@@ -46,6 +46,31 @@ exports.addAll = function() {
 	console.log(success('[✔] Added everything!'));
 };
 
+exports.addSingle = function(target) {
+	//TODO: Fix the Error handling! Currently just ignores warnings
+	exec('git add ' + target, function(error, stdout, stderr){
+		if(!stderr.substring(0, 7) === 'warning'){
+			console.log(whoops('[✖] Could not add target specified? Are you sure the target exists?'));
+		}else{
+				console.log(success('[✔] Added ' + target +' !'));
+		}
+	});
+}
+
+exports.addOptions = function(options, target){
+	// TODO: Fix the Error Handling! Currently just ignores warnings
+	console.log(options + "  -- " + target);
+	exec('git add -' + options + ' ' + target, function(error, stdout, stderr){
+		if(!stderr.substring(0, 7) === 'warning'){
+			console.log(whoops('[✖] Could not add target specified? Are you sure the target exists?'));
+		}else{
+				console.log(success('[✔] Added ' + target +'!'));
+		}
+	});
+
+
+}
+
 exports.commit = function(message) {
 	// No commit message.
 	if (message === '') {


### PR DESCRIPTION
Noticed that there was no way to use it to specify which files you wish to commit, so I split it into two functions.

**Add** which allows you to specify a target. Allows the use of normal options too, such as -v.

Example: `gg a v ./lib/gg.js`

**Add All** what add, a, and aa used to be.

Example `gg aa`

However, this pr raised the issue of error handling in the script. It's a nice hack, but perhaps needs to be standardised.
