### PR TITLE
Add a new alias command for filtering logs with a specific file (enhancement)

### DIFF
--- a/bin/gg
+++ b/bin/gg
@@ -7,7 +7,7 @@ process.bin = process.title = 'gg';
 var gg = require('../lib/gg.js');
 var cli = require('cli');
 
-cli.parse(null, ['i', 'init', 'initialize', 'ig', 'ignore', 'cl', 'clone', 'a', 'aa', 'add', 'c', 'ci', 'commit', 'cn', 'commitnoadd', 'p', 'push', 'pl', 'pull', 'f', 'fetch', 'fa', 's', 'status', 'l', 'log', 'lf', 'b', 'branch', 'ch', 'checkout']);
+cli.parse(null, ['i', 'init', 'initialize', 'ig', 'ignore', 'cl', 'clone', 'a', 'aa', 'add', 'c', 'ci', 'commit', 'cn', 'commitnoadd', 'p', 'push', 'pl', 'pull', 'f', 'fetch', 'fa', 's', 'status', 'l', 'log', 'b', 'branch', 'ch', 'checkout']);
 
 switch (cli.command) {
   // Initialize.
@@ -104,12 +104,7 @@ switch (cli.command) {
   case 'l':
   case 'log':
     var file = cli.args.join(' ');
-    gg.log(file, false);
-    break;
-  // Get log for a specific file
-  case 'lf':
-    var file = cli.args.join(' ');
-    gg.log(file, true);
+    gg.log(file);
     break;
 
   case 'b':

--- a/bin/gg
+++ b/bin/gg
@@ -7,7 +7,7 @@ process.bin = process.title = 'gg';
 var gg = require('../lib/gg.js');
 var cli = require('cli');
 
-cli.parse(null, ['i', 'init', 'initialize', 'ig', 'ignore', 'cl', 'clone', 'a', 'aa', 'add', 'c', 'ci', 'commit', 'cn', 'commitnoadd', 'p', 'push', 'pl', 'pull', 'f', 'fetch', 'fa', 's', 'status', 'l', 'log', 'b', 'branch', 'ch', 'checkout']);
+cli.parse(null, ['i', 'init', 'initialize', 'ig', 'ignore', 'cl', 'clone', 'a', 'aa', 'add', 'c', 'ci', 'commit', 'cn', 'commitnoadd', 'p', 'push', 'pl', 'pull', 'f', 'fetch', 'fa', 's', 'status', 'l', 'log', 'lf', 'b', 'branch', 'ch', 'checkout']);
 
 switch (cli.command) {
   // Initialize.
@@ -103,7 +103,13 @@ switch (cli.command) {
   // Log.
   case 'l':
   case 'log':
-    gg.log();
+    var file = cli.args.join(' ');
+    gg.log(file, false);
+    break;
+  // Get log for a specific file
+  case 'lf':
+    var file = cli.args.join(' ');
+    gg.log(file, true);
     break;
 
   case 'b':

--- a/lib/gg.js
+++ b/lib/gg.js
@@ -397,10 +397,11 @@ exports.status = function() {
   });
 };
 
-exports.log = function() {
+exports.log = function(file, handleFile) {
+  var fileName = ( handleFile ? ' ' + file : '' );
   var logCommand;
   if (isWindows) {
-    exec('git log --pretty=format:{^|commit^|:^|%H^|,%n^|author^|:^|%an:%ae^|,%n^|date^|:^|%ad^|,%n^|message^|:^|%f^|},', function(error, stdout, stderr) {
+    exec('git log --pretty=format:{^|commit^|:^|%H^|,%n^|author^|:^|%an:%ae^|,%n^|date^|:^|%ad^|,%n^|message^|:^|%f^|},' + fileName, function(error, stdout, stderr) {
       stdout = '[' + stdout.replace(/\|/g, '"').slice(0, -1) + ']';
 
       var log = JSON.parse(stdout);
@@ -423,7 +424,7 @@ exports.log = function() {
     });
   } else {
     // https://gist.github.com/textarcana/1306223
-    exec('git log --pretty=format:\'{%n  "commit": "%H",%n  "author": "%an <%ae>",%n  "date": "%ad",%n  "message": "%f"%n},\' $@ | perl -pe \'BEGIN{print "["}; END{print "]\n"}\' | perl -pe \'s/},]/}]/\'', function(error, stdout, stderr) {
+    exec('git log --pretty=format:\'{%n  "commit": "%H",%n  "author": "%an <%ae>",%n  "date": "%ad",%n  "message": "%f"%n},\'' + fileName + ' $@ | perl -pe \'BEGIN{print "["}; END{print "]\n"}\' | perl -pe \'s/},]/}]/\'', function(error, stdout, stderr) {
       var log = JSON.parse(stdout);
       log.reverse(); // Show newest at the bottom.
 

--- a/lib/gg.js
+++ b/lib/gg.js
@@ -397,9 +397,29 @@ exports.status = function() {
   });
 };
 
-exports.log = function(file, handleFile) {
-  var fileName = ( handleFile ? ' ' + file : '' );
+exports.log = function(file) {
+  var fileName = '';
+  var fs = require('fs');
   var logCommand;
+
+  if (file !== 'undefined' && file !== '') {
+    // Testing if the file exists
+    try {
+      // Trying to open the file
+      fs.openSync(file, 'r');
+    }
+    catch (ENOENT) {
+      // If the file does not exist, we tell the user.
+      console.log(whoops('[✖] File ' + file + ' does not exist. '));
+      return;
+    }
+    finally {
+      // We might have other read/write permission errors, etc.
+      // But this is not what we are looking for
+      // So ending here is good to continue, and we can process the git command
+      fileName = ' ' + file;
+    }
+  }
   if (isWindows) {
     exec('git log --pretty=format:{^|commit^|:^|%H^|,%n^|author^|:^|%an:%ae^|,%n^|date^|:^|%ad^|,%n^|message^|:^|%f^|},' + fileName, function(error, stdout, stderr) {
       stdout = '[' + stdout.replace(/\|/g, '"').slice(0, -1) + ']';

--- a/lib/gg.js
+++ b/lib/gg.js
@@ -427,7 +427,7 @@ exports.log = function(file) {
   var fs = require('fs');
   var logCommand;
 
-  if (file !== 'undefined' && file !== '') {
+  if (typeof file !== 'undefined' && file !== '') {
     // Testing if the file exists
     try {
       // Trying to open the file


### PR DESCRIPTION
Hey,

I like sometimes filtering the logs from git logs by extracting only logs where a certain file has been modified. I added an alias to do so, and some code in the exports.log function to handle this case, and gave the alias 'lf' to do so. I was also thinking of adding the feature that allows to see the diff for a specific file over different recent commits, but that would require more code changes, and I'd be interested to know what you think of it before working on it - if I may work on it :).

Let me know what you think of this one in the meantime!
