### PR TITLE
Install over HTTPS in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can see the current local branch and its respective remote branch, the lates
 
 ## Installation
 ```sh
-curl -fsSL git.io/gg.sh | sh
+curl -fsSL https://git.io/gg.sh | sh
 ```
 
 All this installation script does is download the `gg` script, make it an executable, and copy it to your $PATH (/usr/local/bin). For copying to your $PATH, it may require you to enter your password. If there is a better way to do this, please send in a pull request.


### PR DESCRIPTION
Using HTTPS on install via `curl` in README. This will let people trust the "random script" more.
