### PR TITLE
Check if git is already initialized

### DIFF
--- a/bin/gg
+++ b/bin/gg
@@ -150,9 +150,14 @@ version() {
 init() {
 	output=($(git init))
 
-	success "[✔]"
-	success_bold " ${output[0]} "
-	success "${output[1]} Git repository.\n"
+	# Check if git is already initialized
+	if [ -d .git ]; then
+	  whoops " Git is already initialized.\n"
+	else
+		success "[✔]"
+		success_bold " ${output[0]} "
+		success "${output[1]} Git repository.\n"
+	fi;
 }
 
 ignore_list() {


### PR DESCRIPTION
I added a simple check in the `init()` function, to see if `.git` was already initialized. I accidentally ran `$ gg i` in an old repository and all of it's previous history got deleted.

![Self hate](http://i.giphy.com/14eGJZQvtrl1wk.gif)
