### PR TITLE
Fix status() for case where there is no remote repo

### DIFF
--- a/bin/gg
+++ b/bin/gg
@@ -526,39 +526,50 @@ fetch() {
 }
 
 status() {
-	printf "\e[2m\e[90m[\e[22m\e[0m$(success "$(current_branch)") \e[90m->\e[39m $(success "$(current_remote)/$(current_branch)")\e[2m\e[90m|\e[22m\e[0m$(notice $(latest_commit_hash))\e[2m\e[90m]\e[22m\e[0m \e[90m%s\e[39m\n" "$(latest_commit_message)"
+	if [ -z "$(git remote)" ]; then
+		echo "No remote repo."
+		echo
 
-	echo
-
-	# http://stackoverflow.com/a/3278427
-	git fetch --quiet
-
-	LOCAL=$(git rev-parse @{0})
-	REMOTE=$(git rev-parse @{u})
-	BASE=$(git merge-base @{0} @{u})
-
-	push=0
-	pull=0
-
-	if [ "$LOCAL" != "$REMOTE" ]; then
-		position=($(git rev-list --left-right --count $(current_branch)...$(current_remote)/$(current_branch)))
-
-		ahead=${position[0]}
-		behind=${position[1]}
+		has_remote=0
+	else
+		has_remote=1
 	fi
 
-	if [ "$LOCAL" = "$REMOTE" ]; then
-	    display "position" "up-to-date with remote"
-	elif [ "$LOCAL" = "$BASE" ]; then
-	    display_active "position" "$(notice "$behind commits behind remote (pull)")"
-		pull=1
-	elif [ "$REMOTE" = "$BASE" ]; then
-		display_active "position" "$(notice "$ahead commits ahead of remote (push)")"
-		push=1
-	else
-	    display_active "position" "$(whoops "diverged from remote") $(whoops_subtext "($ahead commits ahead, $behind commits behind)")"
-		pull=1
-		push=1
+	if [ $has_remote -eq 1 ];then
+		printf "\e[2m\e[90m[\e[22m\e[0m$(success "$(current_branch)") \e[90m->\e[39m $(success "$(current_remote)/$(current_branch)")\e[2m\e[90m|\e[22m\e[0m$(notice $(latest_commit_hash))\e[2m\e[90m]\e[22m\e[0m \e[90m%s\e[39m\n" "$(latest_commit_message)"
+
+		echo
+
+		# http://stackoverflow.com/a/3278427
+		git fetch --quiet
+
+		LOCAL=$(git rev-parse @{0})
+		REMOTE=$(git rev-parse @{u})
+		BASE=$(git merge-base @{0} @{u})
+
+		push=0
+		pull=0
+
+		if [ "$LOCAL" != "$REMOTE" ]; then
+			position=($(git rev-list --left-right --count $(current_branch)...$(current_remote)/$(current_branch)))
+
+			ahead=${position[0]}
+			behind=${position[1]}
+		fi
+
+		if [ "$LOCAL" = "$REMOTE" ]; then
+		    display "position" "up-to-date with remote"
+		elif [ "$LOCAL" = "$BASE" ]; then
+		    display_active "position" "$(notice "$behind commits behind remote (pull)")"
+			pull=1
+		elif [ "$REMOTE" = "$BASE" ]; then
+			display_active "position" "$(notice "$ahead commits ahead of remote (push)")"
+			push=1
+		else
+		    display_active "position" "$(whoops "diverged from remote") $(whoops_subtext "($ahead commits ahead, $behind commits behind)")"
+			pull=1
+			push=1
+		fi
 	fi
 
 	git diff --exit-code --quiet
@@ -576,24 +587,26 @@ status() {
 		display_active "commits " "$(notice "not all changes committed (commit changes)")"
 	fi
 
-	if [ $push -eq 1 ] | [ $pull -eq 1 ]; then
-		echo
-	fi
+	if [ $has_remote -eq 1 ]; then
+		if [ $push -eq 1 ] | [ $pull -eq 1 ]; then
+			echo
+		fi
 
-	if [ $push -eq 1 ]; then
-		echo
+		if [ $push -eq 1 ]; then
+			echo
 
-		printf "\e[2mcommits ahead (to push):\e[22m\n"
+			printf "\e[2mcommits ahead (to push):\e[22m\n"
 
-		all_commits_to_push_pretty
-	fi
+			all_commits_to_push_pretty
+		fi
 
-	if [ $pull -eq 1 ]; then
-		echo
+		if [ $pull -eq 1 ]; then
+			echo
 
-		printf "\e[2mcommits behind (to pull):\e[22m\n"
+			printf "\e[2mcommits behind (to pull):\e[22m\n"
 
-		all_commits_to_pull_pretty
+			all_commits_to_pull_pretty
+		fi
 	fi
 
 	# Source: http://stackoverflow.com/questions/5096268/git-reports-get-changed-files


### PR DESCRIPTION
When working in a git repo without a remote branch, "gg s" will output errors like: 

```
$ gg s
fatal: no upstream configured for branch 'master'
[master -> /master|0220999] init commit, example.html from webtorrent.io Get Started page

fatal: No remote repository specified.  Please, specify either a URL or a
remote name from which new revisions should be fetched.
fatal: no upstream configured for branch 'master'
fatal: no upstream configured for branch 'master'
fatal: no upstream configured for branch 'master'
fatal: ambiguous argument 'master.../master': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
position |  commits ahead of remote (push)
staging  | not all changes staged (add changes)
commits  | all changes committed

commits ahead (to push):
Could not find a tracked remote branch, please specify <upstream> manually.
usage: git cherry [-v] [<upstream> [<head> [<limit>]]]

    --abbrev[=<n>]        use <n> digits to display SHA-1s
    -v, --verbose         be verbose

 [master|]

files modified:
 |- example.html
```

Simple fix by checking if "git remote" outputs anything, if not, don't do anything that's related to remote repos.
