### PR TITLE
feat: user-specific installation and PATH reminder

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,25 +1,58 @@
 install() {
-	printf "\e[33m[~] Downloading script...\e[0m\n"
+    # Notify the user that the script is being downloaded
+    printf "\e[33m[~] Downloading script...\e[0m\n"
 
-	curl -L#o /var/tmp/gg_$$ https://raw.githubusercontent.com/qw3rtman/gg/master/bin/gg
-	curl -L#o /var/tmp/gg_$$.1 https://raw.githubusercontent.com/qw3rtman/gg/master/man/gg.1
+    # Download the main script and its man page to a temporary location
+    curl -L#o /var/tmp/gg_$$ https://raw.githubusercontent.com/qw3rtman/gg/master/bin/gg
+    curl -L#o /var/tmp/gg_$$.1 https://raw.githubusercontent.com/qw3rtman/gg/master/man/gg.1
 
-	printf "\n\e[33m[~] Setting permissions...\e[0m\n"
+    # Notify the user that permissions are being set
+    printf "\n\e[33m[~] Setting permissions...\e[0m\n"
 
-	chmod -v +x /var/tmp/gg_$$
+    # Make the downloaded script executable
+    chmod -v +x /var/tmp/gg_$$
 
-	echo
+    echo
 
-	printf "\e[33m[~] Moving to \$PATH...\e[0m\n"
+    # Ask the user if they want to install the script system-wide or just for the current user
+    printf "\e[33m[~] Do you want to install gg system-wide or for the current user? (s for system-wide, u for user)\e[0m\n"
+    read -p "(s/u): " choice
 
-	sudo mv -fv /var/tmp/gg_$$ /usr/local/bin/gg
-	sudo mv -fv /var/tmp/gg_$$.1 /usr/local/share/man/man1/gg.1
+    if [ "$choice" = "s" ]; then
+        # Install system-wide
+        printf "\e[33m[~] Moving to /usr/local/bin...\e[0m\n"
+        sudo mv -fv /var/tmp/gg_$$ /usr/local/bin/gg
+        sudo mv -fv /var/tmp/gg_$$.1 /usr/local/share/man/man1/gg.1
+        gg_path="/usr/local/bin/gg"
+    elif [ "$choice" = "u" ]; then
+        # Install for the current user
+        printf "\e[33m[~] Moving to ~/.local/bin...\e[0m\n"
+        mkdir -p $HOME/.local/bin
+        mv -fv /var/tmp/gg_$$ $HOME/.local/bin/gg
+        mkdir -p $HOME/.local/share/man/man1
+        mv -fv /var/tmp/gg_$$.1 $HOME/.local/share/man/man1/gg.1
+        gg_path="$HOME/.local/bin/gg"
 
-	echo
+        # Check if ~/.local/bin is in the PATH
+        if ! echo $PATH | grep -q "$HOME/.local/bin"; then
+            # If not, remind the user to add it to their PATH
+            printf "\n\e[31m[✘] Reminder: ~/.local/bin is not in your PATH. Please add it by running the following command:\e[0m\n"
+            printf "\e[31m[✘] echo 'export PATH=\$HOME/.local/bin:\$PATH' >> ~/.bashrc && source ~/.bashrc\e[0m\n\n"
+        fi
+    else
+        # Handle invalid choice
+        printf "\e[31m[✘] Invalid choice. Exiting...\e[0m\n"
+        exit 1
+    fi
 
-	version=($(gg -V))
+    echo
 
-	printf "\e[32m[✔] Successfully installed Git Goodies v${version}\e[32m!\e[0m\n"
+    # Get the installed version of the script
+    version=($($gg_path -V))
+
+    # Notify the user that the installation was successful
+    printf "\e[32m[✔] Successfully installed Git Goodies v${version}\e[0m!\n"
 }
 
+# Run the install function
 install


### PR DESCRIPTION
Since I always install things like this just for the user, I thought this feature would be nice to have. This enhancement allows for both system-wide and user-specific installation, with a reminder to add the installation path to the user's PATH if necessary.

**What I've done:**
- Added interactive prompt to choose between system-wide and user-specific installation.
- Implemented user-specific installation by moving the script to ~/.local/bin.
- Added check to remind the user to add ~/.local/bin to their PATH if it's not already included.
- Updated the version retrieval to work regardless of the installation path.
- Enhanced script readability with comments explaining each section.